### PR TITLE
move imported objects to a DisplayConduit

### DIFF
--- a/LoadTiles/DisplayConduit.cs
+++ b/LoadTiles/DisplayConduit.cs
@@ -1,0 +1,37 @@
+using System;
+using Rhino;
+using Rhino.Geometry;
+using Rhino.Display;
+using Rhino.DocObjects;
+using System.Collections.Generic;
+
+namespace LoadTiles;
+
+public class TemporaryGeometryConduit : DisplayConduit {
+    private List<RhinoObject> importedObjects;
+
+    public TemporaryGeometryConduit() {
+        this.importedObjects = new List<RhinoObject>();
+        this.Enabled = true;
+    }
+
+    protected override void CalculateBoundingBox(CalculateBoundingBoxEventArgs e) {
+        base.CalculateBoundingBox(e);
+        var bbox = new BoundingBox();
+        bbox.Union(e.Display.Viewport.ConstructionPlane().Origin);
+        foreach (var obj in this.importedObjects) {
+            bbox.Union(obj.Geometry.GetBoundingBox(e.Display.Viewport.ConstructionPlane()));
+        }
+        e.IncludeBoundingBox(bbox);
+    }
+
+    protected override void PreDrawObjects(DrawEventArgs e) {
+        foreach (var obj in this.importedObjects) {
+            e.Display.DrawObject(obj);
+        }
+    }
+
+    public void addObject(RhinoObject obj) {
+        this.importedObjects.Add(obj);
+    }
+}

--- a/LoadTiles/LoadTilesCommand.cs
+++ b/LoadTiles/LoadTilesCommand.cs
@@ -20,6 +20,7 @@ namespace LoadTiles
         public double latitude, longitude, altitude; // We store the last inputted values so that we can write them to file when saving.
         public bool locationInputted = false;
         private string key, session, url;  // For calls to the *Google Maps 3D Tiles* API, not Cesium
+        private TemporaryGeometryConduit displayConduit;
         public LoadTilesCommand()
         {
             // Initialise Http Clients
@@ -39,6 +40,18 @@ namespace LoadTiles
 
         ///<returns>The command name as it appears on the Rhino command line.</returns>
         public override string EnglishName => "Fetch";
+
+        public void hideDisplayConduit() {
+            if (this.displayConduit != null) {
+                this.displayConduit.Enabled = false;
+            }
+        }
+
+        public void restoreDisplayConduit() {
+            if (this.displayConduit != null) {
+                this.displayConduit.Enabled = true;
+            }
+        }
 
         /// <summary>
         /// Makes an API call to retrieve a JSON object
@@ -298,12 +311,19 @@ namespace LoadTiles
                 Console.WriteLine(url);
             }
 
+            List<Guid> existingObjects = new List<Guid>();
+            foreach (var obj in doc.Objects) {
+                existingObjects.Add(obj.Id);
+            }
+
             // Configure location to render
             this.latitude = result.latitude;
             this.longitude = result.longitude;
             this.locationInputted = true;
             this.altitude = 0;  // TODO: Make this user-specified - it affects whether the tiles are loaded above/below the XY-plane
             double renderDistance = 200;  // Radius around target point to load. TODO: Make this user-specified
+
+            this.displayConduit = new TemporaryGeometryConduit();
 
             Point3d targetPoint = Helper.LatLonToEPSG4978(this.latitude, this.longitude, this.altitude);
             // Load tiles
@@ -313,6 +333,14 @@ namespace LoadTiles
 
             doc.Views.ActiveView.ActiveViewport.ZoomExtents();
             RhinoApp.WriteLine("Tiles loaded.");
+
+            foreach (var obj in doc.Objects) {
+                if (!existingObjects.Contains(obj.Id)) {
+                    this.displayConduit.addObject(obj);
+                    doc.Objects.Delete(obj);
+                }
+            }
+
             return Result.Success;
         }
     }

--- a/LoadTiles/LoadTilesPlugin.cs
+++ b/LoadTiles/LoadTilesPlugin.cs
@@ -21,6 +21,46 @@ namespace LoadTiles
             Instance = this;
         }
 
+        protected override Rhino.PlugIns.LoadReturnCode OnLoad(ref string errorMessage) {
+            RhinoDoc.BeginSaveDocument += OnBeginSaveDocument;
+            RhinoDoc.EndSaveDocument += OnEndSaveDocument;
+            return base.OnLoad(ref errorMessage);
+        }
+
+        private void OnBeginSaveDocument(object sender, EventArgs e) {
+            Rhino.Commands.Command[] commands = GetCommands();
+            LoadTilesCommand loadTilesCommand = null;
+            foreach (Rhino.Commands.Command command in commands) {
+                if (command.EnglishName == "Fetch") {
+                    loadTilesCommand = (LoadTilesCommand) command;
+                }
+            }
+            if (loadTilesCommand == null) {
+                Console.WriteLine("Couldn't find the LoadTilesCommand object. Can't automatically hide the display conduit.");
+                return;
+            }
+
+            Console.WriteLine("User is attempting to save. We will hide the display conduit if possible.");
+            loadTilesCommand.hideDisplayConduit();
+        }
+
+        private void OnEndSaveDocument(object sender, EventArgs e) {
+            Rhino.Commands.Command[] commands = GetCommands();
+            LoadTilesCommand loadTilesCommand = null;
+            foreach (Rhino.Commands.Command command in commands) {
+                if (command.EnglishName == "Fetch") {
+                    loadTilesCommand = (LoadTilesCommand) command;
+                }
+            }
+            if (loadTilesCommand == null) {
+                Console.WriteLine("Couldn't find the LoadTilesCommand object. Can't automatically restore the display conduit.");
+                return;
+            }
+
+            Console.WriteLine("Save has been completed. We will restore the display conduit if possible.");
+            loadTilesCommand.restoreDisplayConduit();
+        }
+
         /// <summary>
         /// Called whenever Rhino is about to save a .3dm file. If you want to save
         /// plug-in document data when a model is saved in a version 5 .3dm file, then


### PR DESCRIPTION
The objects imported from the GLB file are placed into a DisplayConduit and then immediately removed from the active document. Therefore there are no objects that will be saved with the project. This is true, because when you reopen the saved project, the objects are not there. However, the file size of the saved project is suddenly much bigger, so I suspect that the objects are somehow in the file, but just not visible. TODO: look into potentially fixing this.